### PR TITLE
Fix two bugs in search function

### DIFF
--- a/screens/clubHomePage.js
+++ b/screens/clubHomePage.js
@@ -38,12 +38,14 @@ class clubHomePage extends Component{
       return true;
     }
     else {
+      console.log('club not found')
+      //console.log(club.clubName,query)
       return false;
     }
   }
 
   handleSearch(queryText) {
-    console.log('query: ',queryText)
+    //console.log('query: ',queryText)
     const formattedQuery = queryText.toLowerCase();
     this.setState({query: formattedQuery})
     console.log('query: ',queryText)
@@ -51,12 +53,7 @@ class clubHomePage extends Component{
       this.setState({clubs: this.state.all_clubs})
     }
     else {
-      /*
-      console.log('query: ',queryText)
-      const formattedQuery = queryText.toLowerCase();
-      this.setState({query: formattedQuery})
-      */
-      const all_clubs = this.state.clubs
+      const all_clubs = this.state.all_clubs
       const filteredClubs = filter(all_clubs, club => {
         return this.contains(club,formattedQuery);
       })


### PR DESCRIPTION
## Trello Ticket :ticket: ##
https://trello.com/c/ro0gdl5V/27-be-fix-bugs-in-search-function

## Summary :chart_with_upwards_trend: ##
Bugs are:
1. Can’t delete the last character in the search bar
2. When a matched text is constructed this way: matched text + unmatched text. Deleting the unmatched part, won’t return the query result of the matched part.

How fixed?
1. Construct the queary text even it is empty.
2. Change the search range from clubs to all_clubs
## Test plan :clipboard: ##
