### PR TITLE
Create group_info page

### DIFF
--- a/components/CommonCompClubCard.js
+++ b/components/CommonCompClubCard.js
@@ -2,12 +2,18 @@ import React from 'react';
 import { StyleSheet, View, Text, Image } from 'react-native';
 import { Card } from 'react-native-paper';
 
-const CommonCompClubCard = ({clubName, clubDesc}) => {
+const CommonCompClubCard = ({clubName, clubDesc, navigation}) => {
     const LeftContent = () => <Image style={styles.clubImage} source={{uri: 'https://www.ieee.org/content/dam/ieee-org/ieee/web/org/about/whatis/71858.gif'}}/>;
- 
+    
+    const viewClub = (navigation,name,desc)=>{
+      navigation.navigate('Club Details',{clubName:name, clubDesc:desc})
+    }
+
     return(
         <View style={styles.container}>
-            <Card style={styles.card}>
+            <Card 
+            style={styles.card}
+            onPress={()=>{viewClub(navigation,clubName,clubDesc)}}>
                 <Card.Title
                 left={LeftContent}
                 leftStyle={styles.imageContainer}

--- a/components/CommonCompClubCard.js
+++ b/components/CommonCompClubCard.js
@@ -2,18 +2,18 @@ import React from 'react';
 import { StyleSheet, View, Text, Image } from 'react-native';
 import { Card } from 'react-native-paper';
 
-const CommonCompClubCard = ({clubName, clubDesc, navigation}) => {
+const CommonCompClubCard = ({clubName, clubDesc, clubCategory, clubEmail, navigation}) => {
     const LeftContent = () => <Image style={styles.clubImage} source={{uri: 'https://www.ieee.org/content/dam/ieee-org/ieee/web/org/about/whatis/71858.gif'}}/>;
     
-    const viewClub = (navigation,name,desc)=>{
-      navigation.navigate('Club Details',{clubName:name, clubDesc:desc})
+    const viewClub = (navigation,name,desc,category,email)=>{
+      navigation.navigate('Club Details',{clubName:name, clubDesc:desc, clubCategory:category, clubEmail:email })
     }
 
     return(
         <View style={styles.container}>
             <Card 
             style={styles.card}
-            onPress={()=>{viewClub(navigation,clubName,clubDesc)}}>
+            onPress={()=>{viewClub(navigation,clubName,clubDesc,clubCategory,clubEmail)}}>
                 <Card.Title
                 left={LeftContent}
                 leftStyle={styles.imageContainer}

--- a/navigations/clubHomePageStack.js
+++ b/navigations/clubHomePageStack.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { createStackNavigator } from "@react-navigation/stack";
+import clubDetailsPage from "../screens/clubDetailsPage";
+import clubHomePage from "../screens/clubHomePage";
+
+const Stack = createStackNavigator();
+
+export default function ClubHomePageStack(){
+    return(
+        <Stack.Navigator
+        initialRouteName = 'clubHomePage'>
+            <Stack.Screen
+            name='Club List'
+            component={clubHomePage}
+            />
+            <Stack.Screen
+            name='Club Details'
+            component={clubDetailsPage}
+            />
+        </Stack.Navigator>
+    )
+}

--- a/navigations/homeTab.js
+++ b/navigations/homeTab.js
@@ -5,6 +5,7 @@ import { Entypo, FontAwesome } from '@expo/vector-icons';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import clubHomePage from '../screens/clubHomePage';
 import eventMapPage from '../screens/eventMapPage';
+import clubHomePageStack from '../navigations/clubHomePageStack';
 
 
 const Tab = createBottomTabNavigator();
@@ -12,13 +13,13 @@ const Tab = createBottomTabNavigator();
 export default function homeTab() {
   return (
     <Tab.Navigator
-      initialRouteName="clubHomePage"
+      initialRouteName="clubHomePageStack"
       tabBarOptions={{
         activeTintColor: '#3DD5F4',
       }}>
       <Tab.Screen
-        name="clubHomePage"
-        component={clubHomePage}
+        name="clubHomePageStack"
+        component={clubHomePageStack}
         options={{
           tabBarLabel: 'Dashboard',
           tabBarIcon: ({ color, size }) => (

--- a/screens/clubDetailsPage.js
+++ b/screens/clubDetailsPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import clubHomePage from './clubHomePage';
-import { StyleSheet, View, Text, Image, SafeAreaView } from 'react-native';
+import { StyleSheet, View, Text, Image, SafeAreaView, ScrollView } from 'react-native';
 
 
 
@@ -12,19 +12,54 @@ class clubDetailsPage extends Component{
             clubDesc : this.props.route.params.clubDesc
         }
     }
-    
+
 
     render(){
         return(
             <SafeAreaView>
-                <Text>{this.state.clubName}</Text>
-                <Text>{this.state.clubDesc}</Text>
+                <ScrollView>
+                    <Text style = {styles.title}>{this.state.clubName}
+                    {'\n'}
+                    </Text>
+                    <Text style = {styles.clubDescription}>{this.state.clubDesc}</Text>
+                </ScrollView>
             </SafeAreaView>
         )
     }
 
 }
 
-
+const styles = StyleSheet.create({
+    title: {
+      fontSize: 22,
+      paddingTop: 10
+    },
+    container: {
+      flex: 1,
+      padding: 10,
+      borderRadius: 40
+    },
+    clubImage: {
+      borderRadius: 25,
+      borderWidth: 2,
+      width: 50,
+      height: 50,
+      marginTop: 15,
+      alignContent: 'center',
+      justifyContent: 'center'
+    },
+    imageContainer: {
+      paddingHorizontal: 0,
+      //borderWidth: 2,
+      width: 60
+    },
+    clubDescription: {
+      fontSize: 14,
+      
+    },
+    card: {
+      height: 100
+    },
+  });
 
 export default clubDetailsPage;

--- a/screens/clubDetailsPage.js
+++ b/screens/clubDetailsPage.js
@@ -9,7 +9,9 @@ class clubDetailsPage extends Component{
         super(props);
         this.state = {
             clubName : this.props.route.params.clubName,
-            clubDesc : this.props.route.params.clubDesc
+            clubDesc : this.props.route.params.clubDesc,
+            clubCategory: this.props.route.params.clubCategory,
+            clubEmail: this.props.route.params.clubEmail
         }
     }
 
@@ -18,10 +20,25 @@ class clubDetailsPage extends Component{
         return(
             <SafeAreaView>
                 <ScrollView>
-                    <Text style = {styles.title}>{this.state.clubName}
+                    <Text style = {styles.title}>
+                    {this.state.clubName}
                     {'\n'}
                     </Text>
-                    <Text style = {styles.clubDescription}>{this.state.clubDesc}</Text>
+                    <Text style = {styles.clubDescription}>
+                        Category:
+                        {'\n'}
+                        {this.state.clubCategory}
+                        {'\n'}
+                        {'\n'}
+                        Email:
+                        {'\n'}
+                        {this.state.clubEmail}
+                        {'\n'}
+                        {'\n'}
+                        Description:
+                        {'\n'}
+                        {this.state.clubDesc}
+                        </Text>
                 </ScrollView>
             </SafeAreaView>
         )

--- a/screens/clubDetailsPage.js
+++ b/screens/clubDetailsPage.js
@@ -18,29 +18,38 @@ class clubDetailsPage extends Component{
 
     render(){
         return(
+            <View style={styles.backcover}>
             <SafeAreaView>
                 <ScrollView>
+                    <View style = {styles.view}>
                     <Text style = {styles.title}>
                     {this.state.clubName}
-                    {'\n'}
+                        {'\n'}
+                    </Text>
+                    <Text style = {styles.subtitle}>
+                        Category:
                     </Text>
                     <Text style = {styles.clubDescription}>
-                        Category:
-                        {'\n'}
                         {this.state.clubCategory}
                         {'\n'}
-                        {'\n'}
+                    </Text>
+                    <Text style = {styles.subtitle}>
                         Email:
-                        {'\n'}
+                    </Text>
+                    <Text style = {styles.email}>
                         {this.state.clubEmail}
                         {'\n'}
-                        {'\n'}
+                    </Text>
+                    <Text style = {styles.subtitle}>
                         Description:
-                        {'\n'}
+                    </Text>
+                    <Text style = {styles.clubDescription}>
                         {this.state.clubDesc}
-                        </Text>
+                    </Text>
+                    </View>
                 </ScrollView>
             </SafeAreaView>
+            </View>
         )
     }
 
@@ -49,8 +58,14 @@ class clubDetailsPage extends Component{
 const styles = StyleSheet.create({
     title: {
       fontSize: 22,
-      paddingTop: 10
+      paddingTop: 10,
+      fontWeight: 'bold'
     },
+    subtitle:{
+      fontSize: 16,
+      fontWeight: 'bold'
+    },
+
     container: {
       flex: 1,
       padding: 10,
@@ -77,6 +92,17 @@ const styles = StyleSheet.create({
     card: {
       height: 100
     },
+    email:{
+    color:'blue',
+    textDecorationLine:'underline'
+    },
+    view:{
+        padding:20,
+        backgroundColor: 'white'
+    },
+    backcover:{
+        backgroundColor: 'white'
+    }
   });
 
 export default clubDetailsPage;

--- a/screens/clubDetailsPage.js
+++ b/screens/clubDetailsPage.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import clubHomePage from './clubHomePage';
+import { StyleSheet, View, Text, Image, SafeAreaView } from 'react-native';
+
+
+
+class clubDetailsPage extends Component{
+    constructor(props){
+        super(props);
+        this.state = {
+            clubName : this.props.route.params.clubName,
+            clubDesc : this.props.route.params.clubDesc
+        }
+    }
+    
+
+    render(){
+        return(
+            <SafeAreaView>
+                <Text>{this.state.clubName}</Text>
+                <Text>{this.state.clubDesc}</Text>
+            </SafeAreaView>
+        )
+    }
+
+}
+
+
+
+export default clubDetailsPage;

--- a/screens/clubHomePage.js
+++ b/screens/clubHomePage.js
@@ -67,13 +67,14 @@ class clubHomePage extends Component{
   render(){
     return(
       <SafeAreaView>
-        <ScrollView>
-          <View>
+        <View>
               <TextInput label="Search" 
                         value = {this.state.query} 
                         type="outlined" 
-                        style = {styles.field}
+                        style = {styles.searchbar}
                         onChangeText={queryText => this.handleSearch(queryText)} />
+        </View>
+        <ScrollView>
            <View>
            {this.state.clubs.map(club => 
            <CommonCompClubCard 
@@ -84,7 +85,6 @@ class clubHomePage extends Component{
               clubEmail = {club.email} 
               navigation={this.props.navigation}/>)}
            </View>
-          </View>
         </ScrollView>
       </SafeAreaView>
     ) 
@@ -97,6 +97,10 @@ const styles = StyleSheet.create({
     margin: 12,
     backgroundColor: 'white',
   },
+  searchbar:{
+    margin:10,
+    backgroundColor: 'white',
+  }
 })
 
 export default clubHomePage;

--- a/screens/clubHomePage.js
+++ b/screens/clubHomePage.js
@@ -36,11 +36,11 @@ class clubHomePage extends Component{
   };
   contains = (club,query) => {
     if (club.clubName.toLowerCase().includes(query) || club.category.toLowerCase().includes(query)) {
-      console.log('club found')
+      //console.log('club found')
       return true;
     }
     else {
-      console.log('club not found')
+      //console.log('club not found')
       //console.log(club.clubName,query)
       return false;
     }
@@ -59,7 +59,7 @@ class clubHomePage extends Component{
       const filteredClubs = filter(all_clubs, club => {
         return this.contains(club,formattedQuery);
       })
-      //console.log('filtered clubs: ',filteredClubs)
+      console.log('filtered clubs: ',filteredClubs)
       this.setState({clubs: filteredClubs})
     }
   }
@@ -75,7 +75,14 @@ class clubHomePage extends Component{
                         style = {styles.field}
                         onChangeText={queryText => this.handleSearch(queryText)} />
            <View>
-           {this.state.clubs.map(club => <CommonCompClubCard clubName={club.clubName} key={club.clubName} clubDesc={club.description} navigation={this.props.navigation}/>)}
+           {this.state.clubs.map(club => 
+           <CommonCompClubCard 
+              clubName={club.clubName} 
+              key={club.clubName} 
+              clubDesc={club.description} 
+              clubCategory= {club.category} 
+              clubEmail = {club.email} 
+              navigation={this.props.navigation}/>)}
            </View>
           </View>
         </ScrollView>

--- a/screens/clubHomePage.js
+++ b/screens/clubHomePage.js
@@ -14,8 +14,10 @@ class clubHomePage extends Component{
       all_clubs: [],
       query: ""
     };
-    this.handleSearch = this.handleSearch.bind(this)
-    this.contains = this.contains.bind(this)
+    this.handleSearch = this.handleSearch.bind(this);
+    this.contains = this.contains.bind(this);
+    //console.log(this.props.navigation)
+    //this.navigation = this.props.navigation.setOptions();
   }
 
   componentDidMount() {
@@ -72,9 +74,8 @@ class clubHomePage extends Component{
                         type="outlined" 
                         style = {styles.field}
                         onChangeText={queryText => this.handleSearch(queryText)} />
-           <CommonCompClubCard clubName="Club Name" clubDesc="This is a club about friendship and trust here at Northwestern. To learn more"/>
            <View>
-           {this.state.clubs.map(club => <CommonCompClubCard clubName={club.clubName} key={club.clubName} clubDesc={club.description}/>)}
+           {this.state.clubs.map(club => <CommonCompClubCard clubName={club.clubName} key={club.clubName} clubDesc={club.description} navigation={this.props.navigation}/>)}
            </View>
           </View>
         </ScrollView>


### PR DESCRIPTION
## Trello Ticket :ticket: ##
https://trello.com/c/2dGYnS3A/25-be-add-club-group-info-page

## Summary :chart_with_upwards_trend: ##
Create group_info page

After clicking the card in the group list, it will now navigate to the club information details!
The club_info page includes the following styling information:
1. club_name
2. club_category
3. club_email
4. club_description

Besides, this branch also quickly fixes the bug to make the search bar in the club list page always floating on the top rather than scrolling with the group card.

## Test plan :clipboard: ##
