### PR TITLE
admin login, admin description editing, admin profile page, styled club details page

### DIFF
--- a/components/CommonCompClubCard.js
+++ b/components/CommonCompClubCard.js
@@ -37,7 +37,8 @@ const CommonCompClubCard = ({clubName, clubDesc, clubCategory, clubEmail, naviga
     },
     container: {
       flex: 1,
-      padding: 10,
+      paddingTop: 10,
+      paddingBottom: 10,
       borderRadius: 40
     },
     clubImage: {

--- a/screens/clubDetailsPage.js
+++ b/screens/clubDetailsPage.js
@@ -16,7 +16,7 @@ class clubDetailsPage extends Component{
             clubId: this.props.route.params.clubId,
             userInfo: {},
             clubmember: false,
-            userId: firebase.auth().currentUser.uid,
+            userId: firebase.auth().currentUser ? firebase.auth().currentUser.uid : "testAdminId", //backdoor token (remove in production)
             edit: false,
             newCat: this.props.route.params.clubCategory,
             newDescription: this.props.route.params.clubDesc,
@@ -107,11 +107,8 @@ class clubDetailsPage extends Component{
         const userClub = firebase.database().ref('/users/'+userId+'/clubs/'+clubId);
         userClub.remove()
         const user = this.state.userInfo
-        console.log('old user: ',user)
         delete user.clubs[clubId]
         this.setState({userInfo: user, clubMember: false});
-        console.log('new user: ',user)
-        console.log('club removed from user')
         this.leaveSuccessfully()
     }
 
@@ -119,7 +116,6 @@ class clubDetailsPage extends Component{
 
     handleEmailClick() {
         const str = 'mailto:'+this.state.clubEmail
-        console.log('str: ',str)
         Linking.openURL(str)
     }
 
@@ -190,8 +186,8 @@ class clubDetailsPage extends Component{
         const admin = this.state.userInfo.admin
         const clubAdmin = this.state.userInfo.clubAdminId
         const currClub = this.state.clubId
-        console.log('clubAdminId: ',clubAdmin)
-        console.log('currClub: ',currClub)
+        //console.log('clubAdminId: ',clubAdmin)
+        //console.log('currClub: ',currClub)
         if (currClub === clubAdmin) {
             return (
                 <Button style={styles.button} mode="outlined" onPress = {this.edit} > Edit Club Description</Button>
@@ -210,8 +206,8 @@ class clubDetailsPage extends Component{
         const admin = this.state.userInfo.admin
         const clubAdmin = this.state.userInfo.clubAdminId
         const currClub = this.state.clubId
-        console.log('clubAdminId: ',clubAdmin)
-        console.log('currClub: ',currClub)
+        //console.log('clubAdminId: ',clubAdmin)
+        //console.log('currClub: ',currClub)
         if (currClub !== clubAdmin) {
             return (
                 <Button style={styles.button} mode="outlined" compact="true" onPress = {this.handleEmailClick}>CONTACT CLUB</Button>
@@ -361,11 +357,6 @@ const styles = StyleSheet.create({
       fontWeight: 'bold'
     },
 
-    //container: {
-    //  flex: 1,
-    //  padding: 10,
-    //  borderRadius: 40
-    //},
     clubImage: {
       borderRadius: 25,
       borderWidth: 2,

--- a/screens/clubDetailsPage.js
+++ b/screens/clubDetailsPage.js
@@ -199,10 +199,6 @@ class clubDetailsPage extends Component{
         }
     }
 
-    saveButton() {
-
-    }
-
     contactClubButton() {
         const admin = this.state.userInfo.admin
         const clubAdmin = this.state.userInfo.clubAdminId

--- a/screens/clubHomePage.js
+++ b/screens/clubHomePage.js
@@ -147,7 +147,7 @@ const styles = StyleSheet.create({
   },
   container: {
     //flex:  1,
-    marginHorizontal:  15,
+    marginHorizontal:  18,
     justifyContent:  'center',
   },
 

--- a/screens/loginPage.js
+++ b/screens/loginPage.js
@@ -60,25 +60,17 @@ class loginPage extends Component {
             googleUser.idToken,
             googleUser.accessToken
           );
-          console.log('clubEmails state: ',this.state.clubEmailsDict["clobel88@gmail.com"])
           // Sign in with credential from the Google user.
           firebase
             .auth()
             .signInAndRetrieveDataWithCredential(credential)
             .then(function(result) {
-              //console.log('doing check of admin email')
-              //console.log('user email: ',result.user.email)
-              //console.log('result.additionalUserInfo.isNewUser: ',result.additionalUserInfo.isNewUser)
-              //console.log('includes: ',this.state.clubEmailsArr.includes(result.user.email))
-             
+              
               
               if (result.additionalUserInfo.isNewUser && admin) {
                 
                 year = 'NA'
 
-                //const emails = this.state.clubEmailsArr
-                //console.log('emails: ',this.state.clubEmailsArr.slice(0,20))
-                
                 console.log('making admin account')
                 firebase
                   .database()
@@ -177,7 +169,6 @@ class loginPage extends Component {
 
   componentDidMount() {
     this.checkIfLoggedIn();
-    console.log('in componentDidMount')
     this.setState({clubEmails: []});
     const db = firebase.database().ref('/clubs');
     
@@ -192,7 +183,6 @@ class loginPage extends Component {
           clubEmailsArray.push(childSnap.email)
           
         });
-      console.log('clubEmailsDict:\n',clubEmailsDictionary["clobel88@gmail.com"])
       this.setState({clubEmailsDict: clubEmailsDictionary, clubEmailsArr: clubEmailsArray});
       }
     })

--- a/screens/loginPage.js
+++ b/screens/loginPage.js
@@ -147,16 +147,17 @@ class loginPage extends Component {
         androidClientId: "466909196535-36phdgnp6t0n65dc8isvj8e7veap29nv.apps.googleusercontent.com",
         scopes: ['profile', 'email']
       });
-      if (result.type === 'success' && result.user.email.includes('@u.northwestern.edu') ) {
-        this.onSignIn(result,false,null);
-        console.log(`successful sign in with userId ${firebase.auth().currentUser.uid}`)
-        return result.accessToken;
-      } 
-      else if (result.type === 'success' && this.state.clubEmailsArr.includes(result.user.email)) {
+      if (result.type === 'success' && this.state.clubEmailsArr.includes(result.user.email)) {
         this.onSignIn(result,true,this.state.clubEmailsDict[result.user.email]);
         console.log(`successful sign in with userId ${firebase.auth().currentUser.uid}`)
         return result.accessToken;
       }
+      else if (result.type === 'success' && result.user.email.includes('@u.northwestern.edu') ) {
+        this.onSignIn(result,false,null);
+        console.log(`successful sign in with userId ${firebase.auth().currentUser.uid}`)
+        return result.accessToken;
+      } 
+      
       else {
         this.loginFailed();
         return { cancelled: true };

--- a/screens/profilePage.js
+++ b/screens/profilePage.js
@@ -13,7 +13,9 @@ class profilePage extends Component{
       edit: false,
       new_name: null,
       new_major: null,
-      new_year: null
+      new_year: null,
+      admin: false,
+      clubInfo: {}
     }
     this.get_profile_comp = this.get_profile_comp.bind(this);
     this.edit = this.edit.bind(this)
@@ -76,15 +78,32 @@ class profilePage extends Component{
       this.setState({userInfo: user,
                     new_year: user.graduation_year,
                   new_major: user.major,
-                  new_name: user.first_name+' '+user.last_name
+                  new_name: user.first_name+' '+user.last_name,
+                  admin: user.admin
                   })
+      if (user.admin) {
+        clubDb = firebase.database().ref('/clubs/'+user.clubAdminId)
+        var club = {}
+        clubDb.on('value', (snapshot) => {
+          if (snapshot.exists()) {
+            club = snapshot.toJSON()
+            console.log('clubInfo: ',club)
+          }
+          this.setState({
+            clubInfo: club
+                      })
+          
+          });
+      }
       console.log('userInfo: ',this.state.userInfo)
       });
+
+
   };
 
   get_profile_comp = () => {
     const user = firebase.auth().currentUser
-    console.log('user: ',user)
+    //console.log('user: ',user)
     if (user.photoURL === '..') {
       return <Avatar.Image size={65} source={user.profile_picture} style={styles.prof_pic}/>
     }
@@ -106,10 +125,13 @@ class profilePage extends Component{
     const year = user.graduation_year
     const major = user.major
     const edit = this.state.edit
-   
-    if (edit) {
-      return (
+    const admin = user.admin
 
+
+
+    if (admin) {
+      const clubName = this.state.clubInfo.clubName
+      return (
 
         <SafeAreaView style={styles.container}>
           <ScrollView>
@@ -117,36 +139,17 @@ class profilePage extends Component{
               {this.get_profile_comp()}
               <Title style={styles.subheading}>{full_name}</Title>
             </View>
-            <Subheading>PERSONAL INFORMATION</Subheading>
+            <Subheading>ADMIN ACCOUNT INFORMATION</Subheading>
             <Card style={styles.card}>
                 <Card.Content>
-                  <Text>Email: {email}</Text>
-                    {/*TODO: CHECK FOR PHONE NUMBER AND DISPLAY IF PRESENT */}
+                  <Text>Club Email: {email}</Text>
                 </Card.Content>
             </Card>
             <Card style={styles.card}>
                 <Card.Content>
-                  <TextInput mode="flat"
-                              label="Graduation Year"
-                              value={this.state.new_year}
-                              dense="true"
-                              onChangeText={text => this.setState({new_year:text})} />
-                    {/*TODO: CHECK FOR PHONE NUMBER AND DISPLAY IF PRESENT */}
+                  <Text>Club Name: {clubName}</Text>
                 </Card.Content>
             </Card>
-            <Card style={styles.card}>
-                <Card.Content>
-                <TextInput mode="flat"
-                              label="Major"
-                              value={this.state.new_major}
-                              dense="true"
-                              onChangeText={text => this.setState({new_major:text})} />
-                </Card.Content>
-            </Card>
-            <View style={styles.row}>
-            <Button mode="contained" dark="true" style={styles.logoutButton} onPress={this.save}>SAVE </Button>
-            <Button mode="contained" dark="true" style={styles.logoutButton} onPress={this.cancel_edit}>CANCEL </Button>
-            </View>
             
             <View style={styles.row}>
               <Button mode="contained" dark="true" style={styles.logoutButton} onPress={this.logout}>logout </Button>
@@ -154,47 +157,100 @@ class profilePage extends Component{
         </ScrollView>
         </SafeAreaView>
         
-      )
-    }
-    else {
-      return (
-
-        <SafeAreaView style={styles.container}>
-          <ScrollView>
-            <View style={styles.container}>
-              {this.get_profile_comp()}
-              <Title style={styles.subheading}>{full_name}</Title>
-            </View>
-            <Subheading>PERSONAL INFORMATION</Subheading>
-            <Card style={styles.card}>
-                <Card.Content>
-                  <Text>Email: {email}</Text>
-                    {/*TODO: CHECK FOR PHONE NUMBER AND DISPLAY IF PRESENT */}
-                </Card.Content>
-            </Card>
-            <Card style={styles.card}>
-                <Card.Content>
-                  <Text>Graduation Year: {year}</Text>
-                    {/*TODO: CHECK FOR PHONE NUMBER AND DISPLAY IF PRESENT */}
-                </Card.Content>
-            </Card>
-            <Card style={styles.card}>
-                <Card.Content>
-                  <Text>Major: {major}</Text>
-                    {/*TODO: CHECK FOR PHONE NUMBER AND DISPLAY IF PRESENT */}
-                </Card.Content>
-            </Card>
-            <View style={styles.row}>
-            <Button mode="contained" dark="true" style={styles.logoutButton} onPress={this.edit}>EDIT </Button>
-            </View>
-            <View style={styles.row}>
-              <Button mode="contained" dark="true" style={styles.logoutButton} onPress={this.logout}>logout </Button>
-            </View>
-        </ScrollView>
-        </SafeAreaView>
-        
       ) }
-  }
+    
+
+
+    else {
+      if (edit) {
+        return (
+
+
+          <SafeAreaView style={styles.container}>
+            <ScrollView>
+              <View style={styles.container}>
+                {this.get_profile_comp()}
+                <Title style={styles.subheading}>{full_name}</Title>
+              </View>
+              <Subheading>PERSONAL INFORMATION</Subheading>
+              <Card style={styles.card}>
+                  <Card.Content>
+                    <Text>Email: {email}</Text>
+                      {/*TODO: CHECK FOR PHONE NUMBER AND DISPLAY IF PRESENT */}
+                  </Card.Content>
+              </Card>
+              <Card style={styles.card}>
+                  <Card.Content>
+                    <TextInput mode="flat"
+                                label="Graduation Year"
+                                value={this.state.new_year}
+                                dense="true"
+                                onChangeText={text => this.setState({new_year:text})} />
+                      {/*TODO: CHECK FOR PHONE NUMBER AND DISPLAY IF PRESENT */}
+                  </Card.Content>
+              </Card>
+              <Card style={styles.card}>
+                  <Card.Content>
+                  <TextInput mode="flat"
+                                label="Major"
+                                value={this.state.new_major}
+                                dense="true"
+                                onChangeText={text => this.setState({new_major:text})} />
+                  </Card.Content>
+              </Card>
+              <View style={styles.row}>
+              <Button mode="contained" dark="true" style={styles.logoutButton} onPress={this.save}>SAVE </Button>
+              <Button mode="contained" dark="true" style={styles.logoutButton} onPress={this.cancel_edit}>CANCEL </Button>
+              </View>
+              
+              <View style={styles.row}>
+                <Button mode="contained" dark="true" style={styles.logoutButton} onPress={this.logout}>logout </Button>
+              </View>
+          </ScrollView>
+          </SafeAreaView>
+          
+        )
+      }
+      else {
+        return (
+
+          <SafeAreaView style={styles.container}>
+            <ScrollView>
+              <View style={styles.container}>
+                {this.get_profile_comp()}
+                <Title style={styles.subheading}>{full_name}</Title>
+              </View>
+              <Subheading>PERSONAL INFORMATION</Subheading>
+              <Card style={styles.card}>
+                  <Card.Content>
+                    <Text>Email: {email}</Text>
+                      {/*TODO: CHECK FOR PHONE NUMBER AND DISPLAY IF PRESENT */}
+                  </Card.Content>
+              </Card>
+              <Card style={styles.card}>
+                  <Card.Content>
+                    <Text>Graduation Year: {year}</Text>
+                      {/*TODO: CHECK FOR PHONE NUMBER AND DISPLAY IF PRESENT */}
+                  </Card.Content>
+              </Card>
+              <Card style={styles.card}>
+                  <Card.Content>
+                    <Text>Major: {major}</Text>
+                      {/*TODO: CHECK FOR PHONE NUMBER AND DISPLAY IF PRESENT */}
+                  </Card.Content>
+              </Card>
+              <View style={styles.row}>
+              <Button mode="contained" dark="true" style={styles.logoutButton} onPress={this.edit}>EDIT </Button>
+              </View>
+              <View style={styles.row}>
+                <Button mode="contained" dark="true" style={styles.logoutButton} onPress={this.logout}>logout </Button>
+              </View>
+          </ScrollView>
+          </SafeAreaView>
+          
+        ) }
+  } 
+}
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Trello Ticket :ticket: ##
https://trello.com/c/6jRMquES
https://trello.com/c/eJDTSrpw

## Summary :chart_with_upwards_trend: ##
- admin login that provides admin access ONLY for the club you are admin of
- admin club description editing capabilities on clubDetails.js screen (right now reach edit page from browse all clubs - location of editing could change to profile page maybe?)
- admin cannot "join" or "contact club" for club it is admin of (buttons don't display) -- right now admin accounts can join/contact clubs for clubs they are not admin of (this can change but some admin emails are student email addresses so wasn't sure what to do here)
- special admin profile page that is less personal - displays email and clubName, no grad year or major
- styled clubDetails page to be consistent with Profile page using card components
- if no description is available - card says "no description available" instead of being blank
- minor - fixed margins on browse all clubs bc search bar was wider than club cards

## Test plan :clipboard: ##
works on iOS